### PR TITLE
Implement contig dma

### DIFF
--- a/include/crono_kernel_interface.h
+++ b/include/crono_kernel_interface.h
@@ -75,66 +75,60 @@ typedef struct {
 } CRONO_KERNEL_CMD;
 
 typedef struct {
-#ifdef _WIN32
-        uint32_t hDma;                    // Handle of DMA buffer
-        void *pUserAddr;                  // Beginning of buffer.
-        CRONO_KERNEL_DMA_PAGE SinglePage; // Since this a struct for contig dma
-                                          // buffer only we just have one page
-#endif
-        DMA_ADDR pPhysicalAddr; // Physical address of page.
-        uint32_t dwBytes;       // Size of buffer.
-} CRONO_KERNEL_DMA_CONTIG;
-
-typedef struct {
         //	uint32_t hDma;             // Handle of DMA buffer
         void *pUserAddr;  // Beginning of buffer.
         uint32_t dwPages; // Number of pages in buffer.
-#ifdef _WIN32
-        CRONO_KERNEL_DMA_PAGE
-        Page[256]; // place holder for array of all page addresses, size will be
-                   // set at runtime. We set a fixed size here, so it is simpler
-                   // to implement on kernel mode and easier to debug
-#elif __linux__
         CRONO_KERNEL_DMA_PAGE *Page;
+
         // Kernel Information
         int id; // Internal kernel ID of the buffer
-#endif
 } CRONO_KERNEL_DMA_SG;
 
+typedef struct {
+        uint32_t hDma;    // Handle of DMA buffer
+        void *pUserAddr;  // Beginning of buffer.
+        uint32_t dwBytes; // Size of buffer.
+        DMA_ADDR pPhysicalAddr;
+
+        // Kernel Information
+        int id; // Internal kernel ID of the buffer
+} CRONO_KERNEL_DMA_CONTIG;
+
 // these are dwOptions
-enum { DMA_KERNEL_BUFFER_ALLOC =
-           0x1, // The system allocates a contiguous buffer.
-                // The user does not need to supply linear address.
+enum {
+        DMA_KERNEL_BUFFER_ALLOC =
+            0x1, // The system allocates a contiguous buffer.
+                 // The user does not need to supply linear address.
 
-       DMA_KBUF_BELOW_16M = 0x2, // If DMA_KERNEL_BUFFER_ALLOC is used,
-                                 // this will make sure it is under 16M.
+        DMA_KBUF_BELOW_16M = 0x2, // If DMA_KERNEL_BUFFER_ALLOC is used,
+                                  // this will make sure it is under 16M.
 
-       DMA_LARGE_BUFFER =
-           0x4, // If DMA_LARGE_BUFFER is used,
-                // the maximum number of pages are dwPages, and not
-                // WD_DMA_PAGES. If you lock a user buffer (not a
-                // kernel allocated buffer) that is larger than 1MB,
-                // then use this option and allocate memory for pages.
+        DMA_LARGE_BUFFER =
+            0x4, // If DMA_LARGE_BUFFER is used,
+                 // the maximum number of pages are dwPages, and not
+                 // WD_DMA_PAGES. If you lock a user buffer (not a
+                 // kernel allocated buffer) that is larger than 1MB,
+                 // then use this option and allocate memory for pages.
 
-       DMA_ALLOW_CACHE = 0x8, // Allow caching of contiguous memory.
+        DMA_ALLOW_CACHE = 0x8, // Allow caching of contiguous memory.
 
-       DMA_KERNEL_ONLY_MAP =
-           0x10, // Only map to kernel, dont map to user-mode.
-                 // relevant with DMA_KERNEL_BUFFER_ALLOC flag only
+        DMA_KERNEL_ONLY_MAP =
+            0x10, // Only map to kernel, dont map to user-mode.
+                  // relevant with DMA_KERNEL_BUFFER_ALLOC flag only
 
-       DMA_FROM_DEVICE =
-           0x20, // memory pages are locked to be written by device
+        DMA_FROM_DEVICE =
+            0x20, // memory pages are locked to be written by device
 
-       DMA_TO_DEVICE = 0x40, // memory pages are locked to be read by device
+        DMA_TO_DEVICE = 0x40, // memory pages are locked to be read by device
 
-       DMA_TO_FROM_DEVICE =
-           (DMA_FROM_DEVICE | DMA_TO_DEVICE), // memory pages are
-                                              // locked for both read and write
+        DMA_TO_FROM_DEVICE =
+            (DMA_FROM_DEVICE | DMA_TO_DEVICE), // memory pages are
+                                               // locked for both read and write
 
-       DMA_ALLOW_64BIT_ADDRESS = 0x80, // Use this value for devices that
-                                       // support 64-bit DMA addressing.
+        DMA_ALLOW_64BIT_ADDRESS = 0x80, // Use this value for devices that
+                                        // support 64-bit DMA addressing.
 
-       DMA_ALLOW_NO_HCARD = 0x100, // allow memory lock without hCard
+        DMA_ALLOW_NO_HCARD = 0x100, // allow memory lock without hCard
 };
 
 /* Macros for backward compatibility */
@@ -338,7 +332,9 @@ CRONO_KERNEL_API uint32_t CRONO_KERNEL_PciReadCfg32(
 CRONO_KERNEL_API uint32_t CRONO_KERNEL_PciWriteCfg32(
     CRONO_KERNEL_DEVICE_HANDLE hDev, uint32_t dwOffset, uint32_t val);
 
-CRONO_KERNEL_API uint32_t CRONO_KERNEL_PciWriteCfg32Arr(CRONO_KERNEL_DEVICE_HANDLE hDev, uint32_t dwOffset, uint32_t* val, uint32_t arr_size);
+CRONO_KERNEL_API uint32_t CRONO_KERNEL_PciWriteCfg32Arr(
+    CRONO_KERNEL_DEVICE_HANDLE hDev, uint32_t dwOffset, uint32_t *val,
+    uint32_t arr_size);
 
 /* -----------------------------------------------
     DMA (Direct Memory Access)

--- a/src/crono_kernel_interface.cpp
+++ b/src/crono_kernel_interface.cpp
@@ -680,7 +680,8 @@ uint32_t CRONO_KERNEL_DMASGBufUnlock(CRONO_KERNEL_DEVICE_HANDLE hDev,
                 free(pDma->Page);
                 pDma->Page = NULL;
         }
-
+        free(pDma);     // Preallocated in `CRONO_KERNEL_DMASGBufLock`
+        
         CRONO_DEBUG("Done unlocking buffer id <%d>.\n", pDma->id);
         return ret;
 }

--- a/src/crono_kernel_interface.cpp
+++ b/src/crono_kernel_interface.cpp
@@ -835,7 +835,7 @@ uint32_t CRONO_KERNEL_DMAContigBufLock(CRONO_KERNEL_DEVICE_HANDLE hDev,
         memset(pDma, 0, sizeof(CRONO_KERNEL_DMA_CONTIG));
         *ppDma = pDma;
         pDma->dwBytes = dwDMABufSize;
-        pDma->pPhysicalAddr = (DMA_ADDR)buff_info.addr;
+        pDma->pPhysicalAddr = (DMA_ADDR)buff_info.dma_handle;
         pDma->id = buff_info.id;
 
         // `mmap` `offset` argument should be aligned on a page boundary, so the
@@ -860,7 +860,7 @@ uint32_t CRONO_KERNEL_DMAContigBufLock(CRONO_KERNEL_DEVICE_HANDLE hDev,
         //
         CRONO_DEBUG("Done locking contiguous buffer id <%d>."
                     "Physical address: <%p>, User Address <%p>\n",
-                    buff_info.id, buff_info.addr, buff_info.pUserAddr);
+                    buff_info.id, pDma->pPhysicalAddr, buff_info.pUserAddr);
         return ret;
 }
 

--- a/src/crono_kernel_interface.cpp
+++ b/src/crono_kernel_interface.cpp
@@ -37,8 +37,6 @@ CRONO_KERNEL_PciScanDevices(uint32_t dwVendorId, uint32_t dwDeviceId,
         uint16_t vendor_id, device_id;
         int index_in_result = 0;
 
-        CRONO_DEBUG("Scanning devices...\n");
-
         if (stat(SYS_BUS_PCIDEVS_PATH, &st) != 0) {
                 printf("Error %d: PCI FS is not found.\n", errno);
                 return errno;
@@ -70,10 +68,6 @@ CRONO_KERNEL_PciScanDevices(uint32_t dwVendorId, uint32_t dwDeviceId,
                         return ret;
                 }
 
-                CRONO_DEBUG("Found device <%s> of Vendor ID <0x%02X>, Device "
-                            "ID <0x%02X>\n",
-                            en->d_name, vendor_id, device_id);
-
                 // Check values & fill pPciScanResult if device matches the
                 // Vendor/Device
                 if (((vendor_id == dwVendorId) ||
@@ -101,7 +95,6 @@ CRONO_KERNEL_PciScanDevices(uint32_t dwVendorId, uint32_t dwDeviceId,
 
         // Clean up
         closedir(dr);
-        CRONO_DEBUG("Finish scanning devices\n");
 
         // Successfully scanned
         return CRONO_SUCCESS;
@@ -840,8 +833,6 @@ uint32_t CRONO_KERNEL_DMAContigBufLock(CRONO_KERNEL_DEVICE_HANDLE hDev,
 
         // `mmap` `offset` argument should be aligned on a page boundary, so the
         // buffer id is sent to `mmap` multiplied by PAGE_SIZE.
-        CRONO_DEBUG("Mapping buffer ID: <%d>, offset <%d>\n", buff_info.id,
-                    buff_info.id * PAGE_SIZE);
         buff_info.pUserAddr = pDma->pUserAddr =
             mmap(NULL, dwDMABufSize, PROT_READ | PROT_WRITE, MAP_SHARED,
                  pDevice->miscdev_fd, buff_info.id * PAGE_SIZE);

--- a/src/crono_kernel_interface.cpp
+++ b/src/crono_kernel_interface.cpp
@@ -850,7 +850,7 @@ uint32_t CRONO_KERNEL_DMAContigBufLock(CRONO_KERNEL_DEVICE_HANDLE hDev,
         // Cleanup, and return
         //
         CRONO_DEBUG("Done locking contiguous buffer id <%d>."
-                    "Physical address: <%p>, User Address <%p>\n",
+                    "Physical address: <0x%lx>, User Address <%p>\n",
                     buff_info.id, pDma->pPhysicalAddr, buff_info.pUserAddr);
         return ret;
 }

--- a/src/crono_kernel_interface.cpp
+++ b/src/crono_kernel_interface.cpp
@@ -836,10 +836,12 @@ uint32_t CRONO_KERNEL_DMAContigBufLock(CRONO_KERNEL_DEVICE_HANDLE hDev,
         *ppDma = pDma;
         pDma->dwBytes = dwDMABufSize;
         pDma->pPhysicalAddr = (DMA_ADDR)buff_info.addr;
+        pDma->id = buff_info.id;
 
         // `mmap` `offset` argument should be aligned on a page boundary, so the
         // buffer id is sent to `mmap` multiplied by PAGE_SIZE.
-        CRONO_DEBUG("Mapping buffer ID: <%d>, offset <%d>\n", buff_info.id, buff_info.id * PAGE_SIZE);
+        CRONO_DEBUG("Mapping buffer ID: <%d>, offset <%d>\n", buff_info.id,
+                    buff_info.id * PAGE_SIZE);
         buff_info.pUserAddr = pDma->pUserAddr =
             mmap(NULL, dwDMABufSize, PROT_READ | PROT_WRITE, MAP_SHARED,
                  pDevice->miscdev_fd, buff_info.id * PAGE_SIZE);

--- a/src/crono_linux_kernel.h
+++ b/src/crono_linux_kernel.h
@@ -21,6 +21,10 @@
 
 typedef uint64_t DMA_ADDR;
 
+/**
+ * @brief
+ * Buffer info communicated with user space for scatter/gather memory
+ */
 typedef struct {
         // Buffer Information
         void *addr;  // Physical address of buffer, allocated by userspace.
@@ -37,7 +41,19 @@ typedef struct {
 
         // Kernel Information
         int id; // Internal kernel ID of the buffer
-} CRONO_BUFFER_INFO;
+} CRONO_SG_BUFFER_INFO;
+
+/**
+ * @brief
+ * Buffer info communicated with user space for contiguous memory
+ */
+typedef struct {
+        void *addr;  // Physical address of buffer, in userspace
+        size_t size; // Size of the buffer in bytes.
+
+        // Kernel Information
+        int id; // Internal kernel ID of the buffer
+} CRONO_CONTIG_BUFFER_INFO;
 
 /**
  * CRONO PCI Driver Name passed in pci_driver structure, and is found under
@@ -86,7 +102,7 @@ typedef struct {
  * Command value passed to miscdev ioctl() to lock a memory buffer.
  * 'c' is for `cronologic`.
  */
-#define IOCTL_CRONO_LOCK_BUFFER _IOWR('c', 0, CRONO_BUFFER_INFO *)
+#define IOCTL_CRONO_LOCK_BUFFER _IOWR('c', 0, CRONO_SG_BUFFER_INFO *)
 /**
  * Command value passed to miscdev ioctl() to unlock a memory buffer
  * 'c' is for `cronologic`. Passing buffer wrapper ID in kernel module.
@@ -96,5 +112,15 @@ typedef struct {
  * Command value passed to miscdev ioctl() to cleanup setup
  */
 #define IOCTL_CRONO_CLEANUP_SETUP _IOWR('c', 2, CRONO_KERNEL_CMDS_INFO *)
+/**
+ * Command value passed to miscdev ioctl() to lock a contiguour memory buffer.
+ * 'c' is for `cronologic`.
+ */
+#define IOCTL_CRONO_LOCK_CONTIG_BUFFER _IOWR('c', 3, CRONO_CONTIG_BUFFER_INFO *)
+/**
+ * Command value passed to miscdev ioctl() to unlock a contiguous memory buffer
+ * 'c' is for `cronologic`. Passing buffer wrapper ID in kernel module.
+ */
+#define IOCTL_CRONO_UNLOCK_CONTIG_BUFFER _IOWR('c', 4, int *)
 
 #endif // #ifndef _CRONO_LINUX_KERNEL_H_

--- a/src/crono_linux_kernel.h
+++ b/src/crono_linux_kernel.h
@@ -50,7 +50,7 @@ typedef struct {
 typedef struct {
         size_t size; // Size of the buffer in bytes.
 
-        void *addr; // Processor's (kernel) virtual address space
+        void *addr; // Memory physical address
         void *pUserAddr;
         uint64_t dma_handle;
 

--- a/src/crono_linux_kernel.h
+++ b/src/crono_linux_kernel.h
@@ -39,7 +39,7 @@ typedef struct {
                          // with kernel versions earlier than 5.6
         uint32_t pages_count; // Count pages in `pages`
 
-        // Kernel Information
+        // Kernel internal information
         int id; // Internal kernel ID of the buffer
 } CRONO_SG_BUFFER_INFO;
 
@@ -48,10 +48,13 @@ typedef struct {
  * Buffer info communicated with user space for contiguous memory
  */
 typedef struct {
-        void *addr;  // Physical address of buffer, in userspace
         size_t size; // Size of the buffer in bytes.
 
-        // Kernel Information
+        void *addr; // Processor's (kernel) virtual address space
+        void *pUserAddr;
+        uint64_t dma_handle;
+
+        // Kernel internal information
         int id; // Internal kernel ID of the buffer
 } CRONO_CONTIG_BUFFER_INFO;
 

--- a/src/sysfs.cpp
+++ b/src/sysfs.cpp
@@ -11,9 +11,10 @@ int crono_read_config(unsigned domain, unsigned bus, unsigned dev,
         int err = CRONO_SUCCESS;
         int fd;
         char *data_bytes = (char *)data;
-#ifdef CRONO_DEBUG_ENABLED
-        pciaddr_t byte_index;
-#endif
+// Uncomment for detailed debug
+// #ifdef CRONO_DEBUG_ENABLED
+//         pciaddr_t byte_index;
+// #endif
         if (bytes_read != NULL) {
                 *bytes_read = 0;
         }
@@ -78,8 +79,8 @@ int crono_read_vendor_device(unsigned domain, unsigned bus, unsigned dev,
                 return err;
         }
 
-        *pVendor = ((uint16_t *)&vendor_device_val)[0];
-        *pDevice = ((uint16_t *)&vendor_device_val)[1];
+        *pVendor = (uint16_t)(vendor_device_val & 0xFFFF);
+        *pDevice = (uint16_t)(vendor_device_val >> 16);
 
 #ifdef CRONO_DEBUG_ENABLED // Uncomment if device is not recognized
         // printf("Read vendor <0x%04X>\n", *pVendor);

--- a/src/sysfs.cpp
+++ b/src/sysfs.cpp
@@ -80,9 +80,9 @@ int crono_read_vendor_device(unsigned domain, unsigned bus, unsigned dev,
         *pVendor = ((uint16_t *)&vendor_device_val)[0];
         *pDevice = ((uint16_t *)&vendor_device_val)[1];
 
-#ifdef CRONO_DEBUG_ENABLED
-        printf("Read vendor <0x%04X>\n", *pVendor);
-        printf("Read device <0x%04X>\n", *pDevice);
+#ifdef CRONO_DEBUG_ENABLED // Uncomment if device is not recognized
+        // printf("Read vendor <0x%04X>\n", *pVendor);
+        // printf("Read device <0x%04X>\n", *pDevice);
 #endif
 
         return err;

--- a/src/sysfs.cpp
+++ b/src/sysfs.cpp
@@ -51,11 +51,11 @@ int crono_read_config(unsigned domain, unsigned bus, unsigned dev,
 
 #ifdef CRONO_DEBUG_ENABLED
         printf("Reading configuration at index <0x%08lX>, size <%ld>"
-                ", file path <%s>\n", 
-                offset, size, config_file_path);
+               ", file path <%s>\n",
+               offset, size, config_file_path);
         for (byte_index = 0; byte_index < size; byte_index++) {
-                printf("Read byte #%03ld: <0x%02X>\n",
-                       byte_index, ((unsigned char *)data)[byte_index]);
+                printf("Read byte #%03ld: <0x%02X>\n", byte_index,
+                       ((unsigned char *)data)[byte_index]);
         }
 #endif
         return err;
@@ -66,25 +66,25 @@ int crono_read_vendor_device(unsigned domain, unsigned bus, unsigned dev,
                              uint16_t *pDevice) {
         pciaddr_t bytes_read;
         int err = CRONO_SUCCESS;
-        
-        // Read Vendor ID and Device ID together from configuration space, 
+
+        // Read Vendor ID and Device ID together from configuration space,
         // offset:0, of 4-bytes length. So, offset is DWORD-aligned for the
         // full value.
-        uint32_t vendor_device_val ; 
-        err = crono_read_config(domain, bus, dev, func, &vendor_device_val, 
-                                0, 4, &bytes_read);
+        uint32_t vendor_device_val;
+        err = crono_read_config(domain, bus, dev, func, &vendor_device_val, 0,
+                                4, &bytes_read);
         if ((bytes_read != 4) || err) {
                 return err;
         }
-        
-        *pVendor = ((uint16_t*)&vendor_device_val)[0];
-        *pDevice = ((uint16_t*)&vendor_device_val)[1];
+
+        *pVendor = ((uint16_t *)&vendor_device_val)[0];
+        *pDevice = ((uint16_t *)&vendor_device_val)[1];
 
 #ifdef CRONO_DEBUG_ENABLED
         printf("Read vendor <0x%04X>\n", *pVendor);
         printf("Read device <0x%04X>\n", *pDevice);
 #endif
-        
+
         return err;
 }
 
@@ -162,7 +162,7 @@ int crono_write_config(unsigned domain, unsigned bus, unsigned dev,
 int crono_get_sys_devices_directory_path(unsigned domain, unsigned bus,
                                          unsigned dev, unsigned func,
                                          char *pPath) {
-        char dev_slink_path[PATH_MAX];  
+        char dev_slink_path[PATH_MAX];
         char dev_slink_content_path[PATH_MAX - 16]; // 16 = "/sys/" + 9
         ssize_t dev_slink_content_len = 0;
 

--- a/src/sysfs.cpp
+++ b/src/sysfs.cpp
@@ -50,13 +50,14 @@ int crono_read_config(unsigned domain, unsigned bus, unsigned dev,
         close(fd);
 
 #ifdef CRONO_DEBUG_ENABLED
-        printf("Reading configuration at index <0x%08lX>, size <%ld>"
-               ", file path <%s>\n",
-               offset, size, config_file_path);
-        for (byte_index = 0; byte_index < size; byte_index++) {
-                printf("Read byte #%03ld: <0x%02X>\n", byte_index,
-                       ((unsigned char *)data)[byte_index]);
-        }
+        // Uncomment for detailed debug
+        // printf("Reading configuration at index <0x%08lX>, size <%ld>"
+        //        ", file path <%s>\n",
+        //        offset, size, config_file_path);
+        // for (byte_index = 0; byte_index < size; byte_index++) {
+        //         printf("Read byte #%03ld: <0x%02X>\n", byte_index,
+        //                ((unsigned char *)data)[byte_index]);
+        // }
 #endif
         return err;
 }

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -59,9 +59,6 @@ add_library(${CRONO_TARGET_NAME} STATIC "${SOURCE}" "${HEADERS}")
 # Remove the `lib` prefix from the library name
 SET_TARGET_PROPERTIES(${CRONO_TARGET_NAME} PROPERTIES PREFIX "")
 
-# Add dependency to target
-crono_add_dep_header("cronologic_linux_kernel-headers")
-
 # Publish packages on conan local cache _______________________________________ 
 IF (NOT CRONO_PUBLISH_LOCAL_PKG STREQUAL "N")
     crono_target_post_build_export_pkg_main()

--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -7,8 +7,8 @@ class CronoPciLinuxConan(ConanFile):
     # __________________________________________________________________________
     # Values to be reviewed with every new version
     #
-    version = "1.0.5"
-    cronologic_kernel_ref = "cronologic_linux_kernel-headers/[~0.0.1]"
+    version = "1.0.0"
+    cronologic_kernel_ref = "cronologic_linux_kernel-headers/[~1.1.0]"
 
     # __________________________________________________________________________
     # Member variables

--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -7,7 +7,7 @@ class CronoPciLinuxConan(ConanFile):
     # __________________________________________________________________________
     # Values to be reviewed with every new version
     #
-    version = "1.0.4"
+    version = "1.0.5"
     cronologic_kernel_ref = "cronologic_linux_kernel-headers/[~0.0.1]"
 
     # __________________________________________________________________________

--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -7,8 +7,7 @@ class CronoPciLinuxConan(ConanFile):
     # __________________________________________________________________________
     # Values to be reviewed with every new version
     #
-    version = "1.0.0"
-    cronologic_kernel_ref = "cronologic_linux_kernel-headers/[~1.1.0]"
+    version = "1.1.0"
 
     # __________________________________________________________________________
     # Member variables
@@ -29,8 +28,6 @@ class CronoPciLinuxConan(ConanFile):
     # ==========================================================================
     # Conan Methods
     #
-    def requirements(self):
-        self.requires(self.cronologic_kernel_ref)
 
     # __________________________________________________________________________
     #


### PR DESCRIPTION
#9 **Support of allocating contiguous memory by the driver** 
- Implementation of `CRONO_KERNEL_DMAContigBufLock` and `CRONO_KERNEL_DMAContigBufUnlock`.
- Use [`cronologic_linux_kernel`](https://github.com/cronologic-de/cronologic_linux_kernel) `v1.1.0`.
- Removed dependency on `cronologic_linux_kernel` package since the package header is already included in the source code.