### PR TITLE
#15 Handle close and multiple open

### DIFF
--- a/src/crono_linux_kernel.h
+++ b/src/crono_linux_kernel.h
@@ -50,7 +50,7 @@ typedef struct {
 typedef struct {
         size_t size; // Size of the buffer in bytes.
 
-        void *addr; // Memory physical address
+        void *addr; // Processor's (kernel) virtual address space
         void *pUserAddr;
         uint64_t dma_handle;
 

--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -7,7 +7,7 @@ class CronoPciLinuxConan(ConanFile):
     # __________________________________________________________________________
     # Values to be reviewed with every new version
     #
-    version = "1.1.2"
+    version = "1.2.0"
 
     # __________________________________________________________________________
     # Member variables


### PR DESCRIPTION
## Work Done
- We currently support `open()` a device only once, opening a device twice is not supported, and returns error to caller.
- Adjust rest of code accordingly.
- Complete `CRONO_KERNEL_PciDeviceClose()` implementation.
- Updated the version.
- Tuning. 