### PR TITLE
DEV-161 use only lib-prefixed .a in linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The initial code has been written by [Bassem Ramzy](https://github.com/Bassem-Ra
 ---
 
 # The Project
-The project generates `crono_pci_linux.a` static lbrary that is used by applications that need to access the kernel driver.
+The project generates `libcrono_pci_linux.a` static lbrary that is used by applications that need to access the kernel driver.
 
 ## Architecture
 <p align="center">
@@ -72,8 +72,8 @@ $ make
 The build target output is:
 | Output | Builds | Description | 
 | -------- | ------ | ----------- |
-| `crono_pci_linux.a` | ``./build/bin/release_64/`` | The release version of the userspace static library |
-| `crono_pci_linux.a` | ``./build/bin/debug_64/`` | The debug version of the userspace static library |
+| `libcrono_pci_linux.a` | ``./build/bin/release_64/`` | The release version of the userspace static library |
+| `libcrono_pci_linux.a` | ``./build/bin/debug_64/`` | The debug version of the userspace static library |
 
 Temporary build files (e.g. `.o` files) are found under the directory ``./build/crono_pci_linux``.
 
@@ -133,7 +133,7 @@ Or, you can clean a specific build as following:
 ---
 
 # Usage 
-The library is provided mainly as a static library `crono_pci_linux.a` to be used by other applications to handle the devices.
+The library is provided mainly as a static library `libcrono_pci_linux.a` to be used by other applications to handle the devices.
 
 ## Header Files
 All the provided APIs and macros are found in the header file [``crono_kernel_interface.h``](./include/crono_kernel_interface.h). 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -56,9 +56,6 @@ set(HEADERS
 # The target library
 add_library(${CRONO_TARGET_NAME} STATIC "${SOURCE}" "${HEADERS}")
 
-# Remove the `lib` prefix from the library name
-SET_TARGET_PROPERTIES(${CRONO_TARGET_NAME} PROPERTIES PREFIX "")
-
 # Publish packages on conan local cache _______________________________________ 
 IF (NOT CRONO_PUBLISH_LOCAL_PKG STREQUAL "N")
     crono_target_post_build_export_pkg_main()

--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -7,7 +7,7 @@ class CronoPciLinuxConan(ConanFile):
     # __________________________________________________________________________
     # Values to be reviewed with every new version
     #
-    version = "1.2.2"
+    version = "1.3.0"
 
     # __________________________________________________________________________
     # Member variables
@@ -32,6 +32,6 @@ class CronoPciLinuxConan(ConanFile):
     # __________________________________________________________________________
     #
     def package(self):
-        super().package(lib_name=self.name)
+        super().package(lib_name="lib"+self.name)
 
     # __________________________________________________________________________


### PR DESCRIPTION
## Updates
- Output library has `lib` prefix now to be `libcrono_pci_linux.a` instead of `crono_pci_linux.a`, for the standardization of the drivers use it.