### PR TITLE
DEV-189 unmmap to fix memory leak

### DIFF
--- a/src/crono_kernel_interface.cpp
+++ b/src/crono_kernel_interface.cpp
@@ -938,10 +938,16 @@ uint32_t CRONO_KERNEL_DMAContigBufUnlock(CRONO_KERNEL_DEVICE_HANDLE hDev,
 void freeDeviceMem(PCRONO_KERNEL_DEVICE pDevice) {
         int iDev;
         for (iDev = 0; iDev < iNewDev; iDev++) {
-                if (pDevice == devices[iDev]) {
-                        free(devices[iDev]);
-                        devices[iDev] = nullptr; // avoid double free
+                if (pDevice != devices[iDev]) 
+                    continue ;
+                if (pDevice->bar_addr.pUserDirectMemAddr) {
+                        if (munmap((void*)pDevice->bar_addr.pUserDirectMemAddr, pDevice->bar_addr.dwSize) == -1) 
+                        { 
+                                printf("Error %d: munmap\n", errno);
+                        }
                 }
+                free(devices[iDev]);
+                devices[iDev] = nullptr; // avoid double free
         }
         // Shrink array for null elements at the end if found
         while (iNewDev > 0 && devices[iNewDev] == nullptr) {

--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -7,7 +7,7 @@ class CronoPciLinuxConan(ConanFile):
     # __________________________________________________________________________
     # Values to be reviewed with every new version
     #
-    version = "1.3.0"
+    version = "1.3.1"
 
     # __________________________________________________________________________
     # Member variables


### PR DESCRIPTION
Use `unmmap` to cleanup memory mapped using `mmap` while process is still active.
It's normally unmmaped when process exits, but, for a multi-thousand open/close it will cause "Out of memory" error.
