### PR TITLE
Support multiple BARs

### DIFF
--- a/include/crono_kernel_interface.h
+++ b/include/crono_kernel_interface.h
@@ -321,6 +321,16 @@ CRONO_KERNEL_API uint32_t CRONO_KERNEL_WriteAddr32(
 CRONO_KERNEL_API uint32_t CRONO_KERNEL_WriteAddr64(
     CRONO_KERNEL_DEVICE_HANDLE hDev, uint32_t dwOffset, uint64_t val);
 
+// Read 32-bit value from the BAR of `barNum`.
+CRONO_KERNEL_API uint32_t CRONO_KERNEL_ReadAddr(CRONO_KERNEL_DEVICE_HANDLE hDev,
+                                                uint32_t dwOffset, uint8_t *val,
+                                                uint32_t barNum);
+
+// Write 32-bit value from the BAR of `barNum`.
+CRONO_KERNEL_API uint32_t
+CRONO_KERNEL_WriteAddr(CRONO_KERNEL_DEVICE_HANDLE hDev, uint32_t dwOffset,
+                       uint64_t val, uint32_t barNum);
+
 /* -----------------------------------------------
     Access PCI configuration space
    ----------------------------------------------- */
@@ -385,7 +395,8 @@ typedef struct {
 
 /**
  * @brief Get device BAR Memory information for all present BARs (upto 6).
- * Memory addresses will not be valid after device is closed.
+ * Memory addresses will not be valid after device is
+ * closed.
  *
  * @param hDev[in]: A valid handle to the device.
  * @param barCount[out]: Number of BarDesc objects filled
@@ -397,6 +408,21 @@ typedef struct {
 CRONO_KERNEL_API uint32_t CRONO_KERNEL_GetBarDescriptions(
     CRONO_KERNEL_DEVICE_HANDLE hDev, uint32_t *barCount,
     CRONO_KERNEL_BAR_DESC *barDescs);
+
+/**
+ * @brief Get device BAR Memory address for barNum.
+ * Memory addresses will not be valid after device is
+ * closed.
+ *
+ * @param hDev[in]: A valid handle to the device.
+ * @param barNum[in]: Number of BAR.
+ * @param barDesc[out]: will hold the CRONO_KERNEL_BAR_DESC address.
+ *
+ * @return CRONO_SUCCESS in case of no error, or errno in case of error.
+ */
+uint32_t CRONO_KERNEL_GetBarDescriptionAddr(CRONO_KERNEL_DEVICE_HANDLE hDev,
+                                            uint32_t barNum,
+                                            CRONO_KERNEL_BAR_DESC **barDesc);
 
 #ifdef __linux__
 /**

--- a/include/crono_kernel_interface.h
+++ b/include/crono_kernel_interface.h
@@ -409,21 +409,6 @@ CRONO_KERNEL_API uint32_t CRONO_KERNEL_GetBarDescriptions(
     CRONO_KERNEL_DEVICE_HANDLE hDev, uint32_t *barCount,
     CRONO_KERNEL_BAR_DESC *barDescs);
 
-/**
- * @brief Get device BAR Memory address for barNum.
- * Memory addresses will not be valid after device is
- * closed.
- *
- * @param hDev[in]: A valid handle to the device.
- * @param barNum[in]: Number of BAR.
- * @param barDesc[out]: will hold the CRONO_KERNEL_BAR_DESC address.
- *
- * @return CRONO_SUCCESS in case of no error, or errno in case of error.
- */
-uint32_t CRONO_KERNEL_GetBarDescriptionAddr(CRONO_KERNEL_DEVICE_HANDLE hDev,
-                                            uint32_t barNum,
-                                            CRONO_KERNEL_BAR_DESC **barDesc);
-
 #ifdef __linux__
 /**
  * Return Error Code `-EINVAL`

--- a/include/crono_kernel_interface.h
+++ b/include/crono_kernel_interface.h
@@ -323,13 +323,13 @@ CRONO_KERNEL_API uint32_t CRONO_KERNEL_WriteAddr64(
 
 // Read 32-bit value from the BAR of `barNum`.
 CRONO_KERNEL_API uint32_t CRONO_KERNEL_ReadAddr(CRONO_KERNEL_DEVICE_HANDLE hDev,
-                                                uint32_t dwOffset, uint8_t *val,
-                                                uint32_t barNum);
+                                                uint32_t dwOffset,
+                                                uint32_t *val, uint32_t barNum);
 
 // Write 32-bit value from the BAR of `barNum`.
 CRONO_KERNEL_API uint32_t
 CRONO_KERNEL_WriteAddr(CRONO_KERNEL_DEVICE_HANDLE hDev, uint32_t dwOffset,
-                       uint64_t val, uint32_t barNum);
+                       uint32_t val, uint32_t barNum);
 
 /* -----------------------------------------------
     Access PCI configuration space

--- a/include/crono_kernel_interface.h
+++ b/include/crono_kernel_interface.h
@@ -324,12 +324,12 @@ CRONO_KERNEL_API uint32_t CRONO_KERNEL_WriteAddr64(
 // Read 32-bit value from the BAR of `barNum`.
 CRONO_KERNEL_API uint32_t CRONO_KERNEL_ReadAddr(CRONO_KERNEL_DEVICE_HANDLE hDev,
                                                 uint32_t dwOffset,
-                                                uint32_t *val, uint32_t barNum);
+                                                uint32_t *val, uint32_t barIndex);
 
 // Write 32-bit value from the BAR of `barNum`.
 CRONO_KERNEL_API uint32_t
 CRONO_KERNEL_WriteAddr(CRONO_KERNEL_DEVICE_HANDLE hDev, uint32_t dwOffset,
-                       uint32_t val, uint32_t barNum);
+                       uint32_t val, uint32_t barIndex);
 
 /* -----------------------------------------------
     Access PCI configuration space

--- a/src/crono_kernel_interface.cpp
+++ b/src/crono_kernel_interface.cpp
@@ -516,21 +516,19 @@ uint32_t CRONO_KERNEL_WriteAddr64(CRONO_KERNEL_DEVICE_HANDLE hDev,
 CRONO_KERNEL_API uint32_t CRONO_KERNEL_ReadAddr(CRONO_KERNEL_DEVICE_HANDLE hDev,
                                                 uint32_t dwOffset,
                                                 uint32_t *val,
-                                                uint32_t barNum) {
-        CRONO_KERNEL_BAR_DESC *barDesc;
-        int ret = CRONO_KERNEL_GetBarDescriptionAddr(hDev, barNum, &barDesc);
-        if (ret != CRONO_SUCCESS)
-                return ret;
+                                                uint32_t barIndex) {
+        CRONO_INIT_HDEV_FUNC(hDev);
 
         // Validation
-        if ((dwOffset + sizeof(val)) > barDesc->length) {
+        if ((dwOffset + sizeof(val)) > pDevice->bar_descs[barIndex].length) {
                 return -ENOMEM;
         }
 
         // Read the value
-        *val =
-            *((volatile uint32_t *)(((unsigned char *)(barDesc->userAddress)) +
-                                    dwOffset));
+        *val = *((
+            volatile uint32_t *)(((unsigned char *)(pDevice->bar_descs[barIndex]
+                                                        .userAddress)) +
+                                 dwOffset));
 
         // Success
         return CRONO_SUCCESS;
@@ -538,19 +536,17 @@ CRONO_KERNEL_API uint32_t CRONO_KERNEL_ReadAddr(CRONO_KERNEL_DEVICE_HANDLE hDev,
 
 CRONO_KERNEL_API uint32_t
 CRONO_KERNEL_WriteAddr(CRONO_KERNEL_DEVICE_HANDLE hDev, uint32_t dwOffset,
-                       uint32_t val, uint32_t barNum) {
-        CRONO_KERNEL_BAR_DESC *barDesc;
-        int ret = CRONO_KERNEL_GetBarDescriptionAddr(hDev, barNum, &barDesc);
-        if (ret != CRONO_SUCCESS)
-                return ret;
+                       uint32_t val, uint32_t barIndex) {
+        CRONO_INIT_HDEV_FUNC(hDev);
 
         // Validation
-        if ((dwOffset + sizeof(val)) > barDesc->length) {
+        if ((dwOffset + sizeof(val)) > pDevice->bar_descs[barIndex].length) {
                 return -ENOMEM;
         }
 
         // Write the value
-        *((volatile uint32_t *)(((unsigned char *)(barDesc->userAddress)) +
+        *((volatile uint32_t *)(((unsigned char *)(pDevice->bar_descs[barIndex]
+                                                       .userAddress)) +
                                 dwOffset)) = val;
 
         // Success

--- a/src/crono_kernel_interface.cpp
+++ b/src/crono_kernel_interface.cpp
@@ -514,7 +514,8 @@ uint32_t CRONO_KERNEL_WriteAddr64(CRONO_KERNEL_DEVICE_HANDLE hDev,
 }
 
 CRONO_KERNEL_API uint32_t CRONO_KERNEL_ReadAddr(CRONO_KERNEL_DEVICE_HANDLE hDev,
-                                                uint32_t dwOffset, uint8_t *val,
+                                                uint32_t dwOffset,
+                                                uint32_t *val,
                                                 uint32_t barNum) {
         CRONO_KERNEL_BAR_DESC *barDesc;
         int ret = CRONO_KERNEL_GetBarDescriptionAddr(hDev, barNum, &barDesc);
@@ -537,7 +538,7 @@ CRONO_KERNEL_API uint32_t CRONO_KERNEL_ReadAddr(CRONO_KERNEL_DEVICE_HANDLE hDev,
 
 CRONO_KERNEL_API uint32_t
 CRONO_KERNEL_WriteAddr(CRONO_KERNEL_DEVICE_HANDLE hDev, uint32_t dwOffset,
-                       uint64_t val, uint32_t barNum) {
+                       uint32_t val, uint32_t barNum) {
         CRONO_KERNEL_BAR_DESC *barDesc;
         int ret = CRONO_KERNEL_GetBarDescriptionAddr(hDev, barNum, &barDesc);
         if (ret != CRONO_SUCCESS)

--- a/src/crono_kernel_interface.cpp
+++ b/src/crono_kernel_interface.cpp
@@ -981,23 +981,6 @@ CRONO_KERNEL_API uint32_t CRONO_KERNEL_GetBarDescriptions(
         return CRONO_SUCCESS;
 }
 
-uint32_t CRONO_KERNEL_GetBarDescriptionAddr(CRONO_KERNEL_DEVICE_HANDLE hDev,
-                                            uint32_t barNum,
-                                            CRONO_KERNEL_BAR_DESC **barDesc) {
-        // Init variables and validate parameters
-        CRONO_INIT_HDEV_FUNC(hDev);
-        CRONO_RET_INV_PARAM_IF_NULL(barDesc);
-
-        for (int barIndex = 0; barIndex < 6; barIndex++) {
-                if (pDevice->bar_descs[barIndex].barNum == barNum) {
-                        *barDesc = &pDevice->bar_descs[barIndex];
-                        return CRONO_SUCCESS;
-                }
-        }
-        *barDesc = nullptr;
-        return -EINVAL;
-}
-
 uint32_t fill_device_bar_descriptions(PCRONO_KERNEL_DEVICE pDevice) {
 
         int ret = CRONO_SUCCESS;

--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -7,7 +7,7 @@ class CronoPciLinuxConan(ConanFile):
     # __________________________________________________________________________
     # Values to be reviewed with every new version
     #
-    version = "2.0.5"
+    version = "2.0.6"
 
     # __________________________________________________________________________
     # Member variables


### PR DESCRIPTION
- Remove unneeded function `CRONO_KERNEL_GetBarDescriptionAddr`.