### PR TITLE
DEV-187 Remove unneeded function CRONO_KERNEL_GetBarDescriptionAddr

### DIFF
--- a/include/crono_kernel_interface.h
+++ b/include/crono_kernel_interface.h
@@ -409,21 +409,6 @@ CRONO_KERNEL_API uint32_t CRONO_KERNEL_GetBarDescriptions(
     CRONO_KERNEL_DEVICE_HANDLE hDev, uint32_t *barCount,
     CRONO_KERNEL_BAR_DESC *barDescs);
 
-/**
- * @brief Get device BAR Memory address for barNum.
- * Memory addresses will not be valid after device is
- * closed.
- *
- * @param hDev[in]: A valid handle to the device.
- * @param barNum[in]: Number of BAR.
- * @param barDesc[out]: will hold the CRONO_KERNEL_BAR_DESC address.
- *
- * @return CRONO_SUCCESS in case of no error, or errno in case of error.
- */
-uint32_t CRONO_KERNEL_GetBarDescriptionAddr(CRONO_KERNEL_DEVICE_HANDLE hDev,
-                                            uint32_t barNum,
-                                            CRONO_KERNEL_BAR_DESC **barDesc);
-
 #ifdef __linux__
 /**
  * Return Error Code `-EINVAL`

--- a/src/crono_kernel_interface.cpp
+++ b/src/crono_kernel_interface.cpp
@@ -981,23 +981,6 @@ CRONO_KERNEL_API uint32_t CRONO_KERNEL_GetBarDescriptions(
         return CRONO_SUCCESS;
 }
 
-uint32_t CRONO_KERNEL_GetBarDescriptionAddr(CRONO_KERNEL_DEVICE_HANDLE hDev,
-                                            uint32_t barNum,
-                                            CRONO_KERNEL_BAR_DESC **barDesc) {
-        // Init variables and validate parameters
-        CRONO_INIT_HDEV_FUNC(hDev);
-        CRONO_RET_INV_PARAM_IF_NULL(barDesc);
-
-        for (int barIndex = 0; barIndex < 6; barIndex++) {
-                if (pDevice->bar_descs[barIndex].barNum == barNum) {
-                        *barDesc = &pDevice->bar_descs[barIndex];
-                        return CRONO_SUCCESS;
-                }
-        }
-        *barDesc = nullptr;
-        return -EINVAL;
-}
-
 uint32_t fill_device_bar_descriptions(PCRONO_KERNEL_DEVICE pDevice) {
 
         int ret = CRONO_SUCCESS;


### PR DESCRIPTION
- Remove unneeded function `CRONO_KERNEL_GetBarDescriptionAddr`.